### PR TITLE
feat: add tar.xz

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = function (buf) {
 		'gz',
 		'rar',
 		'tar',
-		'zip'
+		'zip',
+		'xz'
 	];
 
 	return exts.indexOf(ret && ret.ext) !== -1 ? ret : null;


### PR DESCRIPTION
So https://github.com/kevva/gulp-decompress can use: https://github.com/kevva/decompress-tarxz

Btw I found that weird that we need to change that module to support a new file type
Shouldn't we add an `array` or a `function`: `canHandle` on each strategy?